### PR TITLE
Make getIDToken work in IE

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -161,10 +161,13 @@ function combineCallbacks() {
 }
 
 // TODO: Check issuer
-function verifyIDToken(state, parameters, callback) {
-    if (!parameters || !parameters['id_token']) {
-        return callback(null, parameters);
+function verifyIDToken(state, params, callback) {
+    if (!params || !params['id_token']) {
+        return callback(null, params);
     }
+
+    // This makes it work in IE
+    var parameters = objectAssign({}, params);
 
     var req = request.get(state.conf['jwks_uri']);
     if (req.buffer) { req.buffer(); }


### PR DESCRIPTION
Without this change an error is thrown when trying to access properties of `parameters` in the callback at [line 171](https://github.com/OADA/oada-id-client-js/pull/21/files#diff-7eb52b366866677666470e019283c8eaL171).

What do you think of this @abalmos?