### PR TITLE
Add Saucelabs tests for browser client demo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,3 @@
-# EditorConfig is awesome: http://EditorConfig.org
-
 root = true
 
 # Project wide settings
@@ -17,4 +15,8 @@ indent_size = 2
 
 # Go with how NPM indents package.json
 [package.json]
+indent_size = 2
+
+# Go with how travis indents .travis.yml
+[.travis.yml]
 indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,10 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.coveralls.yml
 
-# Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
+# Grunt intermediate storage
+# (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 
 # Compiled binary addons (http://nodejs.org/api/addons.html)
@@ -29,3 +31,6 @@ node_modules
 
 # "Compiled" stuff
 dist
+
+# Local yeoman stuff
+.yo-rc.json

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,6 @@
 {
     "preset": "google",
     "fileExtensions": [ ".js" ],
-    "validateIndentation": 4
+    "validateIndentation": 4,
+    "excludeFiles": [ "node_modules/**", "coverage/**" ]
 }

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,2 @@
+node_modules/**
+coverage/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: node_js
+node_js:
+- node
+sudo: false
+addons:
+  sauce_connect: true
+before_install:
+- npm install -g grunt-cli mocha
+before_script:
+- grunt demo > demo_output &
+script:
+- grunt jshint
+- grunt lint5
+- grunt style
+- mocha
+after_script:
+- cat demo_output
+env:
+  global:
+  - secure: at6PQ5ZLWpRHzzc/XvZ4oEsjT5Dcs6vHVDlEw/oJ4W6+Uy2k2l6zDnalD5xfifiEt4BL/vhQ7O2W6CkWJTQniUbaQ1hRCLjJF5X2OOjVL5EtqXfrwQnd+j+qMzOnibyPiDKbB9SI8fDk8/my/35YCti19plBWdU4x1M9xpKiPSE=
+  - secure: fjB4cPRkiQKexG/oP0QkD0pS/HHm3VtdQBIFgnQiuTHnQXJ+sw9rBruUIRFFOU5AbuitqarslQcfl4MOhPzk4B+lDzVSEKBgE/uTG2U79xW+lzhxCARlnHBMKJXD/oT+TgBFoHfWQXiNJDmocIjhlfqwcVfm2H0ZnSGY508DrCc=
+  matrix:
+  - BROWSER="chrome"
+  - BROWSER="firefox"
+  - BROWSER="internet explorer"
+  - BROWSER="safari"

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-OADA API Spec
+oada-id-client-js
 Copyright 2014 Open Ag Data Alliance
 
 This product includes software developed at

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-oadaIDClient
+[![Build Status](https://travis-ci.org/OADA/oada-id-client-js.svg?branch=master)](https://travis-ci.org/OADA/oada-id-client-js)
+[![Dependency Status](https://david-dm.org/oada/oada-id-client-js.svg)](https://david-dm.org/oada/oada-id-client-js)
+[![License](http://img.shields.io/:license-Apache%202.0-green.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+
+oada-id-client
 ============
 
 JavaScript client library for OADA identity.

--- a/examples/browser-client/index.html
+++ b/examples/browser-client/index.html
@@ -47,7 +47,7 @@
                 if (console && (typeof console.dir === 'function')) {
                     console.dir(err);
                 }
-                alert(err);
+                alert(err.name + ':' + err.message);
             }
 
             var block = document.getElementById('token');
@@ -67,10 +67,12 @@
     </script>
 </head>
 <body onload="secret()">
-<button onclick="oadaIdClient.getIDToken('identity.oada-dev.com', options,
-    callback)">ID Token</button>
-<button onclick="oadaIdClient.getAccessToken('identity.oada-dev.com', options,
-    callback)">Access Token</button>
+<button id="get_id" onclick="oadaIdClient.getIDToken(
+                        'identity.oada-dev.com', options, callback)">
+    ID Token</button>
+<button id="get_access" onclick="oadaIdClient.getAccessToken(
+                        'identity.oada-dev.com', options, callback)">
+    Access Token</button>
 <div id="secret" style="display:none">
 <!-- The contents of this div only work if you know how to un-break them -->
 <button onclick="oadaIdClient.getIDToken('vip1.ecn.purdue.edu/~awlayton',

--- a/package.json
+++ b/package.json
@@ -30,28 +30,41 @@
   },
   "dependencies": {
     "URIjs": "^1.13.2",
-    "jsonwebtoken": "^1.1.1",
+    "jsonwebtoken": "^4.1.0",
     "jwks-utils": "^0.1.0",
-    "jws": "^0.2.6",
-    "oada-client-secret": "^0.2.2",
+    "jws": "^2.0.0",
+    "oada-client-secret": "^1.0.0",
     "object-assign": "^1.0.0",
     "rsa-pem-from-mod-exp": "^0.8.4",
-    "superagent": "^0.18.2"
+    "superagent": "^1.0.0"
   },
   "devDependencies": {
-    "browserify": "^5.11.1",
+    "async": "^0.9.0",
+    "browserify": "^9.0.3",
+    "chai": "^2.1.1",
+    "colors": "^0.6.2",
     "express": "^4.9.0",
     "grunt": "^0.4.5",
     "grunt-browserify": "^3.0.1",
     "grunt-cli": "^0.1.13",
+    "grunt-concurrent": "^1.0.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-env": "^0.4.1",
     "grunt-express": "^1.4.1",
     "grunt-jscs": "^0.7.1",
     "grunt-lint5": "^0.3.1",
     "grunt-newer": "^0.7.0",
+    "grunt-simple-mocha": "^0.4.0",
+    "istanbul": "^0.3.7",
+    "jscs": "^1.11.3",
+    "jshint": "^2.6.3",
+    "jshint-stylish": "^1.0.1",
     "load-grunt-tasks": "^0.6.0",
+    "lodash": "^2.4.1",
+    "mocha": "^2.2.1",
     "time-grunt": "^1.0.0",
-    "uglifyify": "^2.5.0"
+    "uglifyify": "^2.5.0",
+    "wd": "^0.3.8"
   }
 }

--- a/src/core.js
+++ b/src/core.js
@@ -36,7 +36,7 @@ core.init = function(opts) {
 
 function storeState(stateObj, callback) {
     // Make sure neither or both state storing functions are overridden
-    if (core.retrieveState != retrieveState) {
+    if (core.retrieveState !== retrieveState) {
         return callback(
             new Error('Overrode retrieveState but not storeState!'));
     }
@@ -58,7 +58,7 @@ function storeState(stateObj, callback) {
 
 function retrieveState(stateTok, callback) {
     // Make sure neither or both state storing functions are overridden
-    if (core.storeState != storeState) {
+    if (core.storeState !== storeState) {
         return callback(
             new Error('Overrode storeState but not retrieveState!'));
     }
@@ -230,8 +230,6 @@ function exchangeCode(state, parameters, callback) {
         'client_id': state.options['client_id'],
         'code': parameters.code,
     };
-
-    console.log(params);
 
     request.post(state.conf['token_endpoint'])
         .type('form')

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -19,5 +19,13 @@
     "sub": true,
     "freeze": true,
     "eqeqeq": true,
-    "expr": true
+    "expr": true,
+    "globals": {
+        "describe": true,
+        "it": true,
+        "before": true,
+        "after": true,
+        "afterEach": true,
+        "beforeEach": true
+    }
 }

--- a/test/demo.test.js
+++ b/test/demo.test.js
@@ -1,0 +1,236 @@
+/* Copyright 2015 Open Ag Data Alliance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// Basically runs through the browser client demo with Saucelabs
+
+var expect = require('chai').expect;
+var wd = require('wd');
+require('colors');
+var async = require('async');
+
+var timeout = 60000;
+
+// Assumes demo server is running locally (require Sauce Conect tunnel)
+var demoURL = process.env.DEMO_URL || 'http://localhost:3007/';
+
+// checking sauce credential
+if (!process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY) {
+    console.warn(
+        '\nPlease configure your sauce credential:\n\n' +
+        'export SAUCE_USERNAME=<SAUCE_USERNAME>\n' +
+        'export SAUCE_ACCESS_KEY=<SAUCE_ACCESS_KEY>\n\n'
+    );
+    throw new Error('Missing sauce credentials');
+}
+
+// http configuration, not needed for simple runs
+wd.configureHttp({
+    timeout: timeout,
+    retryDelay: 15000,
+    retries: 5
+});
+
+var username = process.env.SAUCE_USERNAME;
+var accessKey = process.env.SAUCE_ACCESS_KEY;
+
+var desired = {
+    browserName: process.env.BROWSER || 'chrome',
+    version: process.env.VERSION,
+    platform: process.env.PLATFORM
+};
+desired.handle = 'test in ' + desired.browserName;
+desired.tags = [];
+
+var nameSuffix = '';
+
+// Make it work on TravisCI
+if (process.env.TRAVIS) {
+    desired['tunnel-identifier'] = process.env.TRAVIS_JOB_NUMBER;
+    desired.build = process.env.TRAVIS_BUILD_NUMBER;
+    nameSuffix = ' [' + process.env.TRAVIS_JOB_NUMBER + ']';
+    desired.tags.push('branch:' + process.env.TRAVIS_BRANCH);
+    if (process.env.TRAVIS_PULL_REQUEST !== 'false') {
+        desired.tags.push('pull request');
+        desired.tags.push('pull request:' + process.env.TRAVIS_PULL_REQUEST);
+    }
+}
+
+describe(desired.browserName + ' ' + (desired.version || ''), function() {
+    this.timeout(10 * timeout);
+    var browser;
+
+    beforeEach(function(done) {
+        desired.name = this.currentTest.title + nameSuffix;
+        browser = wd.remote(
+                'ondemand.saucelabs.com',
+                80,
+                username,
+                accessKey
+        );
+        if (process.env.VERBOSE) {
+            // optional extra logging
+            browser.on('status', function(info) {
+                console.log(info.cyan);
+            });
+            browser.on('command', function(eventType, command, response) {
+                console.log(
+                        ' > ' + eventType.cyan,
+                        command,
+                        (response || '').grey
+                );
+            });
+            browser.on('http', function(meth, path, data) {
+                console.log(' > ' + meth.magenta, path, (data || '').grey);
+            });
+        }
+        browser.init(desired, done);
+    });
+
+    afterEach(function(done) {
+        browser.quit(function() {
+            browser.sauceJobStatus(this.currentTest.state === 'passed',  done);
+        }.bind(this));
+    });
+
+    describe('browser side client', function() {
+        beforeEach(function(done) {
+            browser.get(demoURL, function() {
+                browser.title(function(err, title) {
+                    expect(err).to.be.not.ok;
+                    expect(title).to.equal('In Browser Usage Example Page');
+                    done();
+                });
+            });
+        });
+        ['access', 'id'].map(function(tokType) {
+            it('should get ' + tokType + ' token', function(done) {
+                async.series([
+                    function(done) {
+                        browser.elementById('get_' + tokType,
+                            function(err, el) {
+                                expect(err).to.be.not.ok;
+                                expect(el).to.be.ok;
+                                el.click(done);
+                            }
+                        );
+                    },
+                    function(done) {
+                        browser.waitFor(
+                            new wd.Asserter(function(browser, cb) {
+                                browser.windowHandles(function(err, handles) {
+                                    expect(err).to.be.not.ok;
+                                    return cb(err, handles.length === 2);
+                                });
+                            }),
+                            timeout,
+                            done
+                        );
+                    },
+                    function(done) {
+                        browser.windowHandles(function(err, handles) {
+                            expect(err).to.be.not.ok;
+                            expect(handles[1]).to.be.ok;
+                            browser.window(handles[1], done);
+                        });
+                    },
+                    function(done) {
+                        browser.waitForElementByName(
+                            'username',
+                            timeout,
+                            function(err, el) {
+                                expect(err).to.be.not.ok;
+                                expect(el).to.be.ok;
+                                el.clear(function(err) {
+                                    expect(err).to.be.not.ok;
+                                    el.type('andy', done);
+                                });
+                            }
+                        );
+                    },
+                    function(done) {
+                        browser.waitForElementByName(
+                            'password',
+                            timeout,
+                            function(err, el) {
+                                expect(err).to.be.not.ok;
+                                expect(el).to.be.ok;
+                                el.clear(function(err) {
+                                    expect(err).to.be.not.ok;
+                                    el.type('pass', done);
+                                });
+                            }
+                        );
+                    },
+                    function(done) {
+                        browser.waitForElementByXPath(
+                            '//input[@type="submit"]',
+                            timeout,
+                            function(err, el) {
+                                expect(err).to.be.not.ok;
+                                expect(el).to.be.ok;
+                                el.click(done);
+                            }
+                        );
+                    },
+                    function(done) {
+                        browser.waitForElementById(
+                            'allow',
+                            timeout,
+                            function(err, el) {
+                                expect(err).to.be.not.ok;
+                                expect(el).to.be.ok;
+                                el.click(done);
+                            }
+                        );
+                    },
+                    function(done) {
+                        browser.windowHandles(function(err, handles) {
+                            expect(err).to.be.not.ok;
+                            expect(handles[0]).to.be.ok;
+                            browser.window(handles[0], done);
+                        });
+                    },
+                    function(done) {
+                        browser.waitFor(
+                            new wd.Asserter(function(browser, cb) {
+                                browser.windowHandles(function(err, handles) {
+                                    expect(err).to.be.not.ok;
+                                    return cb(err, handles.length === 1);
+                                });
+                            }),
+                            timeout,
+                            done
+                        );
+                    },
+                    function(done) {
+                        browser.waitForElementById(
+                            'token',
+                            new wd.Asserter(function(el, cb) {
+                                el.text(function(err, text) {
+                                    expect(err).to.be.not.ok;
+                                    return cb(err, text.length > 0);
+                                });
+                            }),
+                            timeout,
+                            done
+                        );
+                    },
+                ], done);
+            });
+        });
+    });
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--reporter spec
+--ui bdd


### PR DESCRIPTION
This adds tests for getting ID and access tokens with the in-browser version of the library.

The Saucelabs tests finally seem repeatable. Safari is weird sometimes still, but I think it's good enough for now. Travis is set to run the tests in the latest Chrome, Firefox, IE, and Safari.

I would say this resolves #4 and resolves #2.