### PR TITLE
Check for correct audience and issuer in ID token

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -192,7 +192,11 @@ function verifyIDToken(state, params, callback) {
             }
             var key = pem(jwk.n, jwk.e);
 
-            jwt.verify(parameters['id_token'], key, function(err, token) {
+            var opts = {
+                audience: state.options['client_id'],
+                issuer: state.conf.issuer
+            };
+            jwt.verify(parameters['id_token'], key, opts, function(err, token) {
                 if (!err) {
                     // Check nonce
                     if (state.options.nonce === token.nonce) {


### PR DESCRIPTION
Noticed this because of an unrelated bug. I am pretty sure it was supposed to be doing this.

- Compares issuer in ID token (`iss`) against issuer from `openid-configuration` well-known document
- Compares audience in ID token (`aud`) against the `client_id` being used

Tell me if I am wrong about that, or if this fix checks against the wrong things @abalmos.